### PR TITLE
Fix broken regexp rule creation

### DIFF
--- a/bootstrap.js
+++ b/bootstrap.js
@@ -26,7 +26,7 @@ const Utils = (function() {
         let firstChar = pattern.charAt(0);
         let lastChat = pattern.charAt(pattern.length - 1);
         if (firstChar + lastChat === '//') {
-            return new RegExp(pattern.substr(1, -1));
+            return new RegExp(pattern.slice(1, -1));
         } else {
             pattern = '^' + pattern.replace(/\*/g, '.*') + '$';
             return new RegExp(pattern);


### PR DESCRIPTION
.substr(1, -1) would result in an empty string, creating a regexp that would match anything.
Using .slice(1, -1) instead removes the first and last character as intended.