### PR TITLE
Don't apply source-only rules, if there is no initial referrer

### DIFF
--- a/bootstrap.js
+++ b/bootstrap.js
@@ -563,7 +563,8 @@ let Referrer = (function() {
                 isMatch = source.test(sourceURI.spec) &&
                                 target.test(targetURI.spec);
             } else {
-                isMatch = target.test(targetURI.spec);
+                if (target != Utils.fakeTrueTest) // Ignore source-only rules
+                    isMatch = target.test(targetURI.spec);
             }
 
             if (isMatch) {


### PR DESCRIPTION
See #37.
